### PR TITLE
Fix #2 compatibility with dokuwiki 2020-07-29 "Hogfather".

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,14 +19,14 @@ class action_plugin_deniedpage extends DokuWiki_Action_Plugin {
     /**
      * Register its handlers with the dokuwiki's event controller
      */
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
        $controller->register_hook('ACTION_HEADERS_SEND', 'BEFORE', $this, 'handle_action_headers_send');
     }
 
     /**
      * Handle the event
      */ 
-    public function handle_action_headers_send(Doku_Event &$event, $param) {
+    public function handle_action_headers_send(Doku_Event $event, $param) {
       global $ACT;
 
       if ($ACT == 'denied') {


### PR DESCRIPTION
Should fix the following error message in logs
```
PHP message: PHP Fatal error:  
Declaration of action_plugin_deniedpage::register(Doku_Event_Handler &$controller) must be compatible with dokuwiki\\Extension\\ActionPlugin::register(Doku_Event_Handler $controller) in /var/www/dokuwiki/public_html/lib/plugins/deniedpage/action.php on line 0
```